### PR TITLE
snapcrawl 0.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN apt-get update -y && apt-get install -y \
     build-essential patch ruby-dev zlib1g-dev liblzma-dev \
     libfontconfig imagemagick
 
-RUN gem install snapcrawl --version 0.4.2
+RUN gem install snapcrawl --version 0.4.3
 
 ENTRYPOINT ["snapcrawl"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Snapcrawl Docker Image
 ==================================================
 
-![Version](https://img.shields.io/badge/version-0.4.2-blue.svg)
+![Version](https://img.shields.io/badge/version-0.4.3-blue.svg)
 
 [View on GitHub][2] | [View on DockerHub][3]
 


### PR DESCRIPTION
0.4.2 was broken due to docopt load path misconfigured in the gemspec.